### PR TITLE
Bump pyromod from 1.5 to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 motor==3.1.1
 psutil==5.9.4
-pyromod==1.5
+pyromod==2.0.0
 pyrogram==2.0.99
 python-dotenv==0.21.1
 telethon==1.27.0


### PR DESCRIPTION
Bumps [pyromod]() from 1.5 to 2.0.0.

---
updated-dependencies:
- dependency-name: pyromod dependency-type: direct:production update-type: version-update:semver-major ...